### PR TITLE
Replace Meta and Microsoft icons with remote images and drop Other icon

### DIFF
--- a/assets/ai_iq_chart.html
+++ b/assets/ai_iq_chart.html
@@ -232,14 +232,13 @@
           Anthropic: 'https://d2u1z1lopyfwlx.cloudfront.net/thumbnails/c71c2417-1136-5b8f-8384-5be351ff5489/14905bc2-10d7-526a-8286-e84ca4465d93.jpg',
           Google: 'https://d2u1z1lopyfwlx.cloudfront.net/thumbnails/0bc68474-83b9-5d25-8c12-0a3fbd0c056c/d2af60bc-b839-50ac-a580-94b1f1850676.jpg',
           DeepSeek: 'https://uxwing.com/wp-content/themes/uxwing/download/brands-and-social-media/deepseek-logo-icon.svg',
-          Meta: '/assets/icons/meta.svg',
-          Microsoft: '/assets/icons/microsoft.svg',
+          Meta: 'https://d2u1z1lopyfwlx.cloudfront.net/thumbnails/6bbb8e56-b079-58d9-a659-6ce828e8d213/8e7c058c-0cd3-5408-9436-97a6c46ee711.jpg',
+          Microsoft: 'https://d2u1z1lopyfwlx.cloudfront.net/thumbnails/8e0e6171-8e53-5bad-acab-cb95632396c2/dfb8d196-14ec-5e1b-bc6b-d52a6485df78.jpg',
           Qwen: '/assets/icons/qwen.svg',
           Grok: 'https://www.linqto.com/wp-content/themes/linqto2.0/imgs/companies/round/xAI%20round%20%23000000.svg',
           GLM: '/assets/icons/glm.svg',
           Mistral: 'https://app.aicontentlabs.com/v2/providers/square-icons/Mistral.png',
-          Human: '/assets/icons/human.svg',
-          Other: '/assets/icons/other.svg'
+          Human: '/assets/icons/human.svg'
         };
         const families = [
           { key: 'OpenAI', match: /(gpt|o1|o3|o4|openai)/i },

--- a/assets/app.js
+++ b/assets/app.js
@@ -10,13 +10,12 @@
     'DeepSeek': 'https://uxwing.com/wp-content/themes/uxwing/download/brands-and-social-media/deepseek-logo-icon.svg',
     // Use xAI logo for Grok/XAI family
     'Grok': 'https://www.linqto.com/wp-content/themes/linqto2.0/imgs/companies/round/xAI%20round%20%23000000.svg',
-    'Meta': '/assets/icons/meta.svg',
-    'Microsoft': '/assets/icons/microsoft.svg',
+    'Meta': 'https://d2u1z1lopyfwlx.cloudfront.net/thumbnails/6bbb8e56-b079-58d9-a659-6ce828e8d213/8e7c058c-0cd3-5408-9436-97a6c46ee711.jpg',
+    'Microsoft': 'https://d2u1z1lopyfwlx.cloudfront.net/thumbnails/8e0e6171-8e53-5bad-acab-cb95632396c2/dfb8d196-14ec-5e1b-bc6b-d52a6485df78.jpg',
     'GLM': '/assets/icons/glm.svg',
     'Qwen': '/assets/icons/qwen.svg',
     'Mistral': 'https://app.aicontentlabs.com/v2/providers/square-icons/Mistral.png',
-    'Human': '/assets/icons/human.svg',
-    'Other': '/assets/icons/other.svg'
+    'Human': '/assets/icons/human.svg'
   };
 
   // Elements
@@ -45,7 +44,7 @@
     label: 'AI IQ Chart',
     // Use root-relative paths to avoid Vercel "not_found" errors
     url: '/assets/ai_iq_chart.html',
-    icon: '/assets/icons/other.svg',
+    icon: '/assets/favicon.svg',
     source: 'https://www.trackingai.org/home'
   };
   let filters = {

--- a/assets/icons/meta.svg
+++ b/assets/icons/meta.svg
@@ -1,4 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-  <rect width="16" height="16" rx="2" fill="#0081fb"/>
-  <path d="M4 8c0-1.5 1-3 2.5-3S9 6.5 9 8c0 1.5.5 3 2 3s1.5-1.5 1.5-3V5h1v3c0 2.5-1.5 4-3 4s-2.5-1.5-2.5-3c0-1.5-.5-3-2-3S4 6.5 4 8z" fill="white"/>
-</svg>

--- a/assets/icons/microsoft.svg
+++ b/assets/icons/microsoft.svg
@@ -1,6 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-  <rect x="2" y="2" width="5" height="5" fill="#f25022"/>
-  <rect x="9" y="2" width="5" height="5" fill="#7fba00"/>
-  <rect x="2" y="9" width="5" height="5" fill="#00a4ef"/>
-  <rect x="9" y="9" width="5" height="5" fill="#ffb900"/>
-</svg>

--- a/assets/icons/other.svg
+++ b/assets/icons/other.svg
@@ -1,5 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
-  <rect width="16" height="16" rx="4" fill="#8b9db1"/>
-  <path d="M4 8h8M8 4v8" stroke="#0b0e12" stroke-width="2" stroke-linecap="round"/>
-</svg>
-


### PR DESCRIPTION
## Summary
- Replace Meta icon with provided remote image
- Replace Microsoft (Bing Chat) icon with provided remote image
- Remove unused `other.svg` icon and switch external tab to favicon

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c7c6a9d248325bb844d8626532fa2