### PR TITLE
Add benchmark link directory and support multiple external pages

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -38,15 +38,24 @@
 
   // State
   let activeId = datasets[0]?.id;
-  let activeExternal = false;
-  const EXTERNAL_TAB = {
-    id: 'external',
-    label: 'AI IQ Chart',
-    // Use root-relative paths to avoid Vercel "not_found" errors
-    url: '/assets/ai_iq_chart.html',
-    icon: '/assets/favicon.svg',
-    source: 'https://www.trackingai.org/home'
-  };
+  let activeExternal = null; // id of active external tab or null
+  const EXTERNAL_TABS = [
+    {
+      id: 'aiiq',
+      label: 'AI IQ Chart',
+      // Use root-relative paths to avoid Vercel "not_found" errors
+      url: '/assets/ai_iq_chart.html',
+      icon: '/assets/favicon.svg',
+      source: 'https://www.trackingai.org/home'
+    },
+    {
+      id: 'links',
+      label: 'Benchmark Links',
+      url: '/assets/benchmark-links.html',
+      icon: '/assets/favicon.svg',
+      source: ''
+    }
+  ];
   let filters = {
     q: '',
     family: 'all',
@@ -71,19 +80,29 @@
   const decodeHash = () => {
     const h = new URLSearchParams(location.hash.slice(1));
     const target = h.get('id');
-    activeExternal = target === EXTERNAL_TAB.id;
-    if (!activeExternal && target && datasets.find(d => d.id === target)) activeId = target;
-    // Allow overriding external URL via hash
+    if (target && datasets.find(d => d.id === target)) {
+      activeExternal = null;
+      activeId = target;
+    } else if (target && EXTERNAL_TABS.find(t => t.id === target)) {
+      activeExternal = target;
+    }
+    // Allow overriding external URL via hash for active external tab
     const extUrl = h.get('url');
-    if (extUrl) EXTERNAL_TAB.url = extUrl;
+    if (extUrl && activeExternal) {
+      const tab = EXTERNAL_TABS.find(t => t.id === activeExternal);
+      if (tab) tab.url = extUrl;
+    }
     if (h.get('q')) filters.q = h.get('q');
     if (h.get('family')) filters.family = h.get('family');
     if (h.get('sort')) filters.sort = h.get('sort');
     if (h.get('norm')) filters.normalize = h.get('norm') === '1';
   };
   const encodeHash = () => {
-    const params = { id: activeExternal ? EXTERNAL_TAB.id : activeId, q: filters.q, family: filters.family, sort: filters.sort, norm: filters.normalize ? '1' : '0' };
-    if (activeExternal && EXTERNAL_TAB.url) params.url = EXTERNAL_TAB.url;
+    const params = { id: activeExternal || activeId, q: filters.q, family: filters.family, sort: filters.sort, norm: filters.normalize ? '1' : '0' };
+    if (activeExternal) {
+      const tab = EXTERNAL_TABS.find(t => t.id === activeExternal);
+      if (tab && tab.url) params.url = tab.url;
+    }
     const h = new URLSearchParams(params);
     location.hash = h.toString();
     deepLink.textContent = `#${h.toString()}`;
@@ -99,25 +118,27 @@
       btn.setAttribute('aria-selected', (!activeExternal && d.id === activeId) ? 'true' : 'false');
       btn.textContent = d.title;
       btn.addEventListener('click', () => {
-        activeExternal = false;
+        activeExternal = null;
         activeId = d.id;
         buildTabs();
         render();
       });
       tabsEl.appendChild(btn);
     });
-    // External tab
-    const extBtn = document.createElement('button');
-    extBtn.className = `tab ${activeExternal ? 'active' : ''}`;
-    extBtn.setAttribute('role', 'tab');
-    extBtn.setAttribute('aria-selected', activeExternal ? 'true' : 'false');
-    extBtn.innerHTML = `<img class="icon-16" src="${EXTERNAL_TAB.icon}" alt="icon"/> ${EXTERNAL_TAB.label}`;
-    extBtn.addEventListener('click', () => {
-      activeExternal = true;
-      buildTabs();
-      render();
+    // External tabs
+    EXTERNAL_TABS.forEach(tab => {
+      const extBtn = document.createElement('button');
+      extBtn.className = `tab ${activeExternal === tab.id ? 'active' : ''}`;
+      extBtn.setAttribute('role', 'tab');
+      extBtn.setAttribute('aria-selected', activeExternal === tab.id ? 'true' : 'false');
+      extBtn.innerHTML = `<img class="icon-16" src="${tab.icon}" alt="icon"/> ${tab.label}`;
+      extBtn.addEventListener('click', () => {
+        activeExternal = tab.id;
+        buildTabs();
+        render();
+      });
+      tabsEl.appendChild(extBtn);
     });
-    tabsEl.appendChild(extBtn);
   }
 
   function buildFamilyFilter(data) {
@@ -323,16 +344,17 @@
   function render() {
     // Toggle external vs internal views
     if (activeExternal) {
+      const tab = EXTERNAL_TABS.find(t => t.id === activeExternal);
       controlsEl.hidden = true;
       chartEl.hidden = true;
       tableEl.hidden = true;
       legendEl.hidden = true;
       externalWrap.hidden = false;
-      if (externalFrame.src !== EXTERNAL_TAB.url) externalFrame.src = EXTERNAL_TAB.url;
-      const src = EXTERNAL_TAB.source && typeof EXTERNAL_TAB.source === 'string' && EXTERNAL_TAB.source.trim() ? EXTERNAL_TAB.source.trim() : '';
+      if (tab && externalFrame.src !== tab.url) externalFrame.src = tab.url;
+      const src = tab && tab.source && typeof tab.source === 'string' && tab.source.trim() ? tab.source.trim() : '';
       datasetMeta.innerHTML = src
-        ? `<span class="model-name"><img class="icon-16" src="${EXTERNAL_TAB.icon}" alt="icon"/> ${EXTERNAL_TAB.label}</span> • <a href="${src}" target="_blank" rel="noopener">Source</a>`
-        : `<span class="model-name"><img class="icon-16" src="${EXTERNAL_TAB.icon}" alt="icon"/> ${EXTERNAL_TAB.label}</span>`;
+        ? `<span class="model-name"><img class="icon-16" src="${tab.icon}" alt="icon"/> ${tab.label}</span> • <a href="${src}" target="_blank" rel="noopener">Source</a>`
+        : `<span class="model-name"><img class="icon-16" src="${tab ? tab.icon : ''}" alt="icon"/> ${tab ? tab.label : ''}</span>`;
       selectionMeta.textContent = `Embedded page`;
       encodeHash();
       return;

--- a/assets/benchmark-links.html
+++ b/assets/benchmark-links.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Benchmark Links</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      table{width:100%;border-collapse:collapse;background:var(--surface);border:1px solid var(--muted);border-radius:12px;overflow:hidden}
+      th,td{padding:8px 12px;border-bottom:1px solid var(--muted);text-align:left}
+      th{font-weight:600;background:var(--surface)}
+      tr:last-child td{border-bottom:none}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">Benchmark Links</h1>
+      <table>
+        <thead>
+          <tr><th>Benchmark</th><th>URL</th><th>Category</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>BenchCouncil AI Bench</td><td><a href="links/benchcouncil-ai-bench.html">https://www.benchcouncil.org/aibench/</a></td><td>Benchmark Suite</td></tr>
+          <tr><td>AI Benchmark</td><td><a href="links/ai-benchmark.html">https://ai-benchmark.com/</a></td><td>Benchmark Suite</td></tr>
+          <tr><td>Geekbench AI</td><td><a href="links/geekbench-ai.html">https://www.geekbench.com/ai/</a></td><td>Benchmark Suite</td></tr>
+          <tr><td>LiveBench</td><td><a href="links/livebench.html">https://livebench.ai/</a></td><td>Benchmark Suite</td></tr>
+          <tr><td>SimpleBench</td><td><a href="links/simplebench.html">https://simple-bench.com/</a></td><td>Benchmark Suite</td></tr>
+          <tr><td>CS‑Bench</td><td><a href="links/cs-bench.html">https://csbench.github.io/</a></td><td>Benchmark Suite</td></tr>
+          <tr><td>EQ‑Bench</td><td><a href="links/eq-bench.html">https://eqbench.com/</a></td><td>Benchmark Suite</td></tr>
+          <tr><td>SWE‑bench</td><td><a href="links/swe-bench.html">https://swebench.com/</a></td><td>Code Benchmark</td></tr>
+          <tr><td>DeepResearch Bench</td><td><a href="links/deepresearch-bench.html">https://deepresearch-bench.github.io/</a></td><td>Benchmark Suite</td></tr>
+          <tr><td>GLUE Benchmark</td><td><a href="links/glue-benchmark.html">https://gluebenchmark.com/</a></td><td>NLP Dataset</td></tr>
+          <tr><td>SuperGLUE</td><td><a href="links/superglue.html">https://super.gluebenchmark.com/</a></td><td>NLP Dataset</td></tr>
+          <tr><td>SQuAD</td><td><a href="links/squad.html">https://rajpurkar.github.io/SQuAD-explorer/</a></td><td>NLP Dataset</td></tr>
+          <tr><td>HellaSwag</td><td><a href="links/hellaswag.html">https://rowanzellers.com/hellaswag/</a></td><td>NLP Dataset</td></tr>
+          <tr><td>MMLU</td><td><a href="links/mmlu.html">https://huggingface.co/datasets/cais/mmlu</a></td><td>NLP Dataset</td></tr>
+          <tr><td>BIG‑bench</td><td><a href="links/big-bench.html">https://huggingface.co/datasets/google/bigbench</a></td><td>NLP Dataset</td></tr>
+          <tr><td>ARC (AI2 Reasoning Challenge)</td><td><a href="links/ai2-arc.html">https://huggingface.co/datasets/ai2_arc</a></td><td>NLP Dataset</td></tr>
+          <tr><td>TruthfulQA</td><td><a href="links/truthfulqa.html">https://huggingface.co/datasets/TruthfulQA</a></td><td>NLP Dataset</td></tr>
+          <tr><td>DROP</td><td><a href="links/drop.html">https://huggingface.co/datasets/drop</a></td><td>NLP Dataset</td></tr>
+          <tr><td>GSM8K</td><td><a href="links/gsm8k.html">https://huggingface.co/datasets/openai/gsm8k</a></td><td>NLP Dataset</td></tr>
+          <tr><td>BigBench Hard (BBH)</td><td><a href="links/bigbench-hard-bbh.html">https://huggingface.co/datasets/bigbench/bbh</a></td><td>NLP Dataset</td></tr>
+          <tr><td>MT‑Bench‑101</td><td><a href="links/mt-bench-101.html">https://arxiv.org/abs/2402.08321</a></td><td>NLP Dataset</td></tr>
+          <tr><td>AGIEval</td><td><a href="links/agieval.html">https://huggingface.co/datasets/agieval</a></td><td>NLP Dataset</td></tr>
+          <tr><td>Evidently AI LLM Benchmarks</td><td><a href="links/evidently-ai-llm-benchmarks.html">https://evidentlyai.com/llm-evaluation-benchmarks</a></td><td>Benchmark Suite</td></tr>
+          <tr><td>HumanEval</td><td><a href="links/humaneval.html">https://github.com/openai/human-eval</a></td><td>Code Benchmark</td></tr>
+        </tbody>
+      </table>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/agieval.html
+++ b/assets/links/agieval.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AGIEval</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">AGIEval</h1>
+      <p>Category: NLP Dataset</p>
+      <p><a href="https://huggingface.co/datasets/agieval" target="_blank" rel="noopener">https://huggingface.co/datasets/agieval</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/ai-benchmark.html
+++ b/assets/links/ai-benchmark.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AI Benchmark</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">AI Benchmark</h1>
+      <p>Category: Benchmark Suite</p>
+      <p><a href="https://ai-benchmark.com/" target="_blank" rel="noopener">https://ai-benchmark.com/</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/ai2-arc.html
+++ b/assets/links/ai2-arc.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ARC (AI2 Reasoning Challenge)</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">ARC (AI2 Reasoning Challenge)</h1>
+      <p>Category: NLP Dataset</p>
+      <p><a href="https://huggingface.co/datasets/ai2_arc" target="_blank" rel="noopener">https://huggingface.co/datasets/ai2_arc</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/benchcouncil-ai-bench.html
+++ b/assets/links/benchcouncil-ai-bench.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BenchCouncil AI Bench</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">BenchCouncil AI Bench</h1>
+      <p>Category: Benchmark Suite</p>
+      <p><a href="https://www.benchcouncil.org/aibench/" target="_blank" rel="noopener">https://www.benchcouncil.org/aibench/</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/big-bench.html
+++ b/assets/links/big-bench.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BIG‑bench</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">BIG‑bench</h1>
+      <p>Category: NLP Dataset</p>
+      <p><a href="https://huggingface.co/datasets/google/bigbench" target="_blank" rel="noopener">https://huggingface.co/datasets/google/bigbench</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/bigbench-hard-bbh.html
+++ b/assets/links/bigbench-hard-bbh.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BigBench Hard (BBH)</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">BigBench Hard (BBH)</h1>
+      <p>Category: NLP Dataset</p>
+      <p><a href="https://huggingface.co/datasets/bigbench/bbh" target="_blank" rel="noopener">https://huggingface.co/datasets/bigbench/bbh</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/cs-bench.html
+++ b/assets/links/cs-bench.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CS‑Bench</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">CS‑Bench</h1>
+      <p>Category: Benchmark Suite</p>
+      <p><a href="https://csbench.github.io/" target="_blank" rel="noopener">https://csbench.github.io/</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/deepresearch-bench.html
+++ b/assets/links/deepresearch-bench.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>DeepResearch Bench</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">DeepResearch Bench</h1>
+      <p>Category: Benchmark Suite</p>
+      <p><a href="https://deepresearch-bench.github.io/" target="_blank" rel="noopener">https://deepresearch-bench.github.io/</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/drop.html
+++ b/assets/links/drop.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>DROP</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">DROP</h1>
+      <p>Category: NLP Dataset</p>
+      <p><a href="https://huggingface.co/datasets/drop" target="_blank" rel="noopener">https://huggingface.co/datasets/drop</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/eq-bench.html
+++ b/assets/links/eq-bench.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>EQ‑Bench</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">EQ‑Bench</h1>
+      <p>Category: Benchmark Suite</p>
+      <p><a href="https://eqbench.com/" target="_blank" rel="noopener">https://eqbench.com/</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/evidently-ai-llm-benchmarks.html
+++ b/assets/links/evidently-ai-llm-benchmarks.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Evidently AI LLM Benchmarks</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">Evidently AI LLM Benchmarks</h1>
+      <p>Category: Benchmark Suite</p>
+      <p><a href="https://evidentlyai.com/llm-evaluation-benchmarks" target="_blank" rel="noopener">https://evidentlyai.com/llm-evaluation-benchmarks</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/geekbench-ai.html
+++ b/assets/links/geekbench-ai.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Geekbench AI</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">Geekbench AI</h1>
+      <p>Category: Benchmark Suite</p>
+      <p><a href="https://www.geekbench.com/ai/" target="_blank" rel="noopener">https://www.geekbench.com/ai/</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/glue-benchmark.html
+++ b/assets/links/glue-benchmark.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GLUE Benchmark</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">GLUE Benchmark</h1>
+      <p>Category: NLP Dataset</p>
+      <p><a href="https://gluebenchmark.com/" target="_blank" rel="noopener">https://gluebenchmark.com/</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/gsm8k.html
+++ b/assets/links/gsm8k.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>GSM8K</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">GSM8K</h1>
+      <p>Category: NLP Dataset</p>
+      <p><a href="https://huggingface.co/datasets/openai/gsm8k" target="_blank" rel="noopener">https://huggingface.co/datasets/openai/gsm8k</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/hellaswag.html
+++ b/assets/links/hellaswag.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>HellaSwag</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">HellaSwag</h1>
+      <p>Category: NLP Dataset</p>
+      <p><a href="https://rowanzellers.com/hellaswag/" target="_blank" rel="noopener">https://rowanzellers.com/hellaswag/</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/humaneval.html
+++ b/assets/links/humaneval.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>HumanEval</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">HumanEval</h1>
+      <p>Category: Code Benchmark</p>
+      <p><a href="https://github.com/openai/human-eval" target="_blank" rel="noopener">https://github.com/openai/human-eval</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/livebench.html
+++ b/assets/links/livebench.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>LiveBench</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">LiveBench</h1>
+      <p>Category: Benchmark Suite</p>
+      <p><a href="https://livebench.ai/" target="_blank" rel="noopener">https://livebench.ai/</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/mmlu.html
+++ b/assets/links/mmlu.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MMLU</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">MMLU</h1>
+      <p>Category: NLP Dataset</p>
+      <p><a href="https://huggingface.co/datasets/cais/mmlu" target="_blank" rel="noopener">https://huggingface.co/datasets/cais/mmlu</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/mt-bench-101.html
+++ b/assets/links/mt-bench-101.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MT‑Bench‑101</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">MT‑Bench‑101</h1>
+      <p>Category: NLP Dataset</p>
+      <p><a href="https://arxiv.org/abs/2402.08321" target="_blank" rel="noopener">https://arxiv.org/abs/2402.08321</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/simplebench.html
+++ b/assets/links/simplebench.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SimpleBench</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">SimpleBench</h1>
+      <p>Category: Benchmark Suite</p>
+      <p><a href="https://simple-bench.com/" target="_blank" rel="noopener">https://simple-bench.com/</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/squad.html
+++ b/assets/links/squad.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SQuAD</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">SQuAD</h1>
+      <p>Category: NLP Dataset</p>
+      <p><a href="https://rajpurkar.github.io/SQuAD-explorer/" target="_blank" rel="noopener">https://rajpurkar.github.io/SQuAD-explorer/</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/superglue.html
+++ b/assets/links/superglue.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SuperGLUE</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">SuperGLUE</h1>
+      <p>Category: NLP Dataset</p>
+      <p><a href="https://super.gluebenchmark.com/" target="_blank" rel="noopener">https://super.gluebenchmark.com/</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/swe-bench.html
+++ b/assets/links/swe-bench.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SWE‑bench</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">SWE‑bench</h1>
+      <p>Category: Code Benchmark</p>
+      <p><a href="https://swebench.com/" target="_blank" rel="noopener">https://swebench.com/</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>

--- a/assets/links/truthfulqa.html
+++ b/assets/links/truthfulqa.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TruthfulQA</title>
+    <style>
+      :root{--bg:#0b0e12;--surface:#10151b;--text:#e7edf3;--muted:#9fb0c0;color-scheme:dark only;}
+      [data-theme="light"]{--bg:#f7f9fc;--surface:#ffffff;--text:#0b0e12;--muted:#475569;color-scheme:light only;}
+      body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial}
+      main{max-width:900px;margin:24px auto;padding:0 16px}
+      a{color:var(--text)}
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1 style="margin:0 0 12px 0">TruthfulQA</h1>
+      <p>Category: NLP Dataset</p>
+      <p><a href="https://huggingface.co/datasets/TruthfulQA" target="_blank" rel="noopener">https://huggingface.co/datasets/TruthfulQA</a></p>
+    </main>
+    <script>
+      (function syncTheme(){
+        const saved = localStorage.getItem('theme');
+        if (saved) document.documentElement.dataset.theme = saved;
+      })();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add standalone `benchmark-links.html` page listing common AI benchmark resources
- Extend `app.js` to handle multiple external tabs including the new link directory
- Generate individual link pages for each benchmark with category tags

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a830b5150c8325b9663676db7f989d